### PR TITLE
Remove trailing : from oms.symantec.com

### DIFF
--- a/hostnames.whitelist.txt
+++ b/hostnames.whitelist.txt
@@ -38,7 +38,7 @@
  cdn.flipboard.com
 
 # symantect Records user logins to management console
- oms.symantec.com:
+ oms.symantec.com
 
 # prevents the first time visiting google.com in a session from being blocked
  device-provisioning.googleapis.com


### PR DESCRIPTION
There's a trailing ':' after oms.symantec.com. Remove it so it's just a hostname.